### PR TITLE
add pydocstyle and update some versions

### DIFF
--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -6,14 +6,20 @@ repos:
   - id: check-merge-conflict
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
 
 - repo: https://github.com/psf/black
-  rev: 22.8.0
+  rev: 23.3.0
   hooks:
   - id: black
+
+- repo: https://github.com/pycqa/pydocstyle
+  rev: 6.3.0
+  hooks:
+    - id: pydocstyle
+      additional_dependencies: [tomli]
 
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4

--- a/template/pyproject.toml.j2
+++ b/template/pyproject.toml.j2
@@ -5,6 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "{{ project_name }}"
 readme = "README.md"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 authors = [
     {name = "{{ author_name }}", email = "{{ author_email }}"}
@@ -16,10 +17,10 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 dynamic = ["version", "description"]
 
@@ -41,12 +42,15 @@ test = [
 doc = [
     "furo",
     "myst-parser",
-    "sphinx~=4.3.0",
+    "sphinx>=5",
     "sphinx-copybutton",
 ]
 
 [tool.isort]
 profile = "black"
+
+[tool.pydocstyle]
+convention = "numpy"
 
 [tool.mypy]
 python_version = "3.7"


### PR DESCRIPTION
I have added pydocstyle back, now as a pre-commit check, and removed the sphinx pin.
While at it, I have also updated a couple versions in the pre-commit-hooks and
added a requires python >=3.8 which seemed the most conservative yet sensible
choice right now that 3.7 is very close to its end of life.
