### PR TITLE
Bring back pydocstyle (via ruff)

### DIFF
--- a/template/pyproject.toml.j2
+++ b/template/pyproject.toml.j2
@@ -46,22 +46,20 @@ doc = [
     "sphinx-copybutton",
 ]
 
-[tool.isort]
-profile = "black"
-
-[tool.pydocstyle]
-convention = "numpy"
-
 [tool.ruff]
 show-fixes = true
 select = [
     "F",  # Pyflakes
     "E",  # Pycodestyle
     "W",  # Pycodestyle
+    "D",  # Pydocstyle
     "UP",  # pyupgrade
     "I",  # isort
     "PL",  # Pylint
 ]
+
+[tool.ruff.pydocstyle]
+convention = "numpy"
 
 [tool.mypy]
 python_version = "3.7"

--- a/template/pyproject.toml.j2
+++ b/template/pyproject.toml.j2
@@ -58,6 +58,9 @@ select = [
     "PL",  # Pylint
 ]
 
+[tool.ruff.per-file-ignores]
+"tests/**/*" = ["D", "PLR2004"]
+
 [tool.ruff.pydocstyle]
 convention = "numpy"
 


### PR DESCRIPTION
Testing the ruff updates :smile:. I realized pydocstyle checks
were gone, this should add them again via ruff "D" rules.
Will test this now but it seems quite straightforward from https://docs.astral.sh/ruff/settings/#pydocstyle

